### PR TITLE
[Develop smart feature] Fixing clean message and delete filter bar from the landlords homepage

### DIFF
--- a/Andlet/Andlet/Views/Homepage/HomepageView.swift
+++ b/Andlet/Andlet/Views/Homepage/HomepageView.swift
@@ -61,7 +61,7 @@ struct HomepageView: View {
                                 .frame(width: 0, height: 0)  // Oculto, pero activo
                         )
                         .alert(isPresented: $showShakeAlert) {
-                            Alert(title: Text("Shake Detected"), message: Text("You have refreshed the offers!"), dismissButton: .default(Text("OK")))
+                            Alert(title: Text("Shake Detected"), message: Text("Filters have been cleared🧹!"), dismissButton: .default(Text("OK")))
                         }
                         .onReceive(shakeDetector.$didShake) { didShake in
                             if didShake {

--- a/Andlet/Andlet/Views/HomepageRent/HomepageRentView.swift
+++ b/Andlet/Andlet/Views/HomepageRent/HomepageRentView.swift
@@ -28,12 +28,6 @@ struct HomepageRentView: View {
                     ScrollView {
                         VStack {
                             Heading()
-                            SearchAndFilterBar()
-                                .onTapGesture {
-                                    withAnimation(.snappy) {
-                                        showFilterSearchView.toggle()
-                                    }
-                                }
                             CreateMoreButton()
                         
                             if viewModel.offersWithProperties.isEmpty {


### PR DESCRIPTION
This pull request includes changes to the alert message in `HomepageView.swift` and the removal of the `SearchAndFilterBar` component in `HomepageRentView.swift`.

Changes to alert message:

* [`Andlet/Andlet/Views/Homepage/HomepageView.swift`](diffhunk://#diff-7d546b836df13d3666235ebaed45b0cc3aade9e96c4d993e179e9f5a0090361eL64-R64): Updated the alert message text from "You have refreshed the offers!" to "Filters have been cleared🧹!"

Removal of `SearchAndFilterBar`:

* [`Andlet/Andlet/Views/HomepageRent/HomepageRentView.swift`](diffhunk://#diff-a3a0bb37b5d00a01fb50e0d6d320f6685d6b610f91fe092ea23cba43ada059ccL31-L36): Removed the `SearchAndFilterBar` component and its associated tap gesture animation.