### PR TITLE
[Bug fix] Fixing roommates calculate

### DIFF
--- a/Andlet/Andlet.xcodeproj/project.pbxproj
+++ b/Andlet/Andlet.xcodeproj/project.pbxproj
@@ -898,7 +898,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Andlet/Preview Content\"";
-				DEVELOPMENT_TEAM = 62CHFB9B3W;
+				DEVELOPMENT_TEAM = 25L8P5DHHR;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -922,7 +922,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.4;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = team23.Andlet.daniel;
+				PRODUCT_BUNDLE_IDENTIFIER = team23.Andlet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
@@ -941,7 +941,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Andlet/Preview Content\"";
-				DEVELOPMENT_TEAM = 62CHFB9B3W;
+				DEVELOPMENT_TEAM = 25L8P5DHHR;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -965,7 +965,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.4;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = team23.Andlet.daniel;
+				PRODUCT_BUNDLE_IDENTIFIER = team23.Andlet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";

--- a/Andlet/Andlet/Info.plist
+++ b/Andlet/Andlet/Info.plist
@@ -31,6 +31,16 @@
 		<string>LeagueSpartan-SemiBold.ttf</string>
 		<string>Montserrat-ExtraLightItalic.ttf</string>
 	</array>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+    	<string>We need your location to notify you about offers near the university.</string>
+   	<key>NSLocationWhenInUseUsageDescription</key>
+    	<string>We need your location to notify you about offers near the university.</string>
+    	<key>NSLocationAlwaysUsageDescription</key>
+    	<string>We need your location even when the app is in the background.</string>
+    <key>UIBackgroundModes</key>
+    <array>
+        <string>location</string>
+    </array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>location</string>

--- a/Andlet/Andlet/Info.plist
+++ b/Andlet/Andlet/Info.plist
@@ -31,17 +31,9 @@
 		<string>LeagueSpartan-SemiBold.ttf</string>
 		<string>Montserrat-ExtraLightItalic.ttf</string>
 	</array>
-    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-    <string>We need your location to notify you about offers near the university.</string>
-    <key>NSLocationWhenInUseUsageDescription</key>
-    <string>We need your location to notify you about offers near the university.</string>
-    <key>NSLocationAlwaysUsageDescription</key>
-    <string>We need your location even when the app is in the background.</string>
-
-    <key>UIBackgroundModes</key>
-    <array>
-        <string>location</string>
-    </array>
-
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 </dict>
 </plist>

--- a/Andlet/Andlet/ViewModels/Properties/PropertyOfferData.swift
+++ b/Andlet/Andlet/ViewModels/Properties/PropertyOfferData.swift
@@ -59,11 +59,8 @@ class PropertyOfferData: ObservableObject, CustomStringConvertible {
 
     // Método para actualizar el valor de `roommates` según el valor de `numBeds`
     private func updateRoommates() {
-        if numBeds == 1 {
-            roommates = 0
-        } else {
-            roommates = numBeds
-        }
+        roommates = numBeds-1
+        
     }
 
     func offerDetails() -> String {


### PR DESCRIPTION
This pull request includes several changes to the `Andlet` project configuration and codebase. The most important changes involve updating project settings, removing location permission descriptions, and simplifying the `updateRoommates` method in the `PropertyOfferData` class.

### Project Configuration Updates:

* [`Andlet/Andlet.xcodeproj/project.pbxproj`](diffhunk://#diff-d3cff5f946b3503428e0dd1f002bf6898a97f6b4baa62e6062e3856b5a21f523L901-R901): Updated the `DEVELOPMENT_TEAM` identifier from `62CHFB9B3W` to `25L8P5DHHR`. [[1]](diffhunk://#diff-d3cff5f946b3503428e0dd1f002bf6898a97f6b4baa62e6062e3856b5a21f523L901-R901) [[2]](diffhunk://#diff-d3cff5f946b3503428e0dd1f002bf6898a97f6b4baa62e6062e3856b5a21f523L944-R944)
* [`Andlet/Andlet.xcodeproj/project.pbxproj`](diffhunk://#diff-d3cff5f946b3503428e0dd1f002bf6898a97f6b4baa62e6062e3856b5a21f523L925-R925): Changed the `PRODUCT_BUNDLE_IDENTIFIER` from `team23.Andlet.daniel` to `team23.Andlet`. [[1]](diffhunk://#diff-d3cff5f946b3503428e0dd1f002bf6898a97f6b4baa62e6062e3856b5a21f523L925-R925) [[2]](diffhunk://#diff-d3cff5f946b3503428e0dd1f002bf6898a97f6b4baa62e6062e3856b5a21f523L968-R968)

### Permission Descriptions Removal:

* [`Andlet/Andlet/Info.plist`](diffhunk://#diff-d4722d7d0498ca54726819cf80010e656bb1b82e6295f364e7d15468a5249103L34-L45): Removed location permission descriptions (`NSLocationAlwaysAndWhenInUseUsageDescription`, `NSLocationWhenInUseUsageDescription`, `NSLocationAlwaysUsageDescription`).

### Code Simplification:

* [`Andlet/Andlet/ViewModels/Properties/PropertyOfferData.swift`](diffhunk://#diff-644eef89c1d750e150b8d0bceaa73c0838478cd453369d2887624ba2b3cf4423L62-R63): Simplified the `updateRoommates` method to set `roommates` directly as `numBeds-1`.