### PR TITLE
[BugFix] LigthMode always on

### DIFF
--- a/Andlet/Andlet/Info.plist
+++ b/Andlet/Andlet/Info.plist
@@ -31,6 +31,8 @@
 		<string>LeagueSpartan-SemiBold.ttf</string>
 		<string>Montserrat-ExtraLightItalic.ttf</string>
 	</array>
+    <key>UIUserInterfaceStyle</key>
+    <string>Light</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
     	<string>We need your location to notify you about offers near the university.</string>
    	<key>NSLocationWhenInUseUsageDescription</key>


### PR DESCRIPTION
This pull request includes a small but important change to the `Info.plist` file to specify the user interface style for the application.

* [`Andlet/Andlet/Info.plist`](diffhunk://#diff-d4722d7d0498ca54726819cf80010e656bb1b82e6295f364e7d15468a5249103R34-R35): Added `UIUserInterfaceStyle` key with the value `Light` to enforce a light interface style across the application.