### PR TITLE
[Fix bugs] landlords offer view ready, filters and photos

### DIFF
--- a/Andlet/Andlet.xcodeproj/project.pbxproj
+++ b/Andlet/Andlet.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		3781D2622CA530AD00C43924 /* OfferDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3781D2612CA530A300C43924 /* OfferDetailViewModel.swift */; };
 		3781D2642CA64C5400C43924 /* OfferRentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3781D2632CA64C4B00C43924 /* OfferRentViewModel.swift */; };
 		3781D2662CA650D900C43924 /* OfferWithProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3781D2652CA650CC00C43924 /* OfferWithProperty.swift */; };
+		3784CC3E2CC3379A00A0B7E9 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3784CC3C2CC3379A00A0B7E9 /* ImageCacheManager.swift */; };
 		37A512E52CACD46300B62788 /* UserActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A512E42CACD45D00B62788 /* UserActions.swift */; };
 		37A512E72CACD8F500B62788 /* CheckDaysSinceLastContact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A512E62CACD8E400B62788 /* CheckDaysSinceLastContact.swift */; };
 		37C0E28C2C9E58F500099A90 /* FiltersSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C0E28B2C9E58F500099A90 /* FiltersSearchView.swift */; };
@@ -125,6 +126,7 @@
 		3781D2612CA530A300C43924 /* OfferDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferDetailViewModel.swift; sourceTree = "<group>"; };
 		3781D2632CA64C4B00C43924 /* OfferRentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferRentViewModel.swift; sourceTree = "<group>"; };
 		3781D2652CA650CC00C43924 /* OfferWithProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferWithProperty.swift; sourceTree = "<group>"; };
+		3784CC3C2CC3379A00A0B7E9 /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		37A512E42CACD45D00B62788 /* UserActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserActions.swift; sourceTree = "<group>"; };
 		37A512E62CACD8E400B62788 /* CheckDaysSinceLastContact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckDaysSinceLastContact.swift; sourceTree = "<group>"; };
 		37C0E28B2C9E58F500099A90 /* FiltersSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersSearchView.swift; sourceTree = "<group>"; };
@@ -250,6 +252,21 @@
 			path = Offers;
 			sourceTree = "<group>";
 		};
+		3784CC3B2CC3376A00A0B7E9 /* New Group */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "New Group";
+			sourceTree = "<group>";
+		};
+		3784CC3D2CC3379A00A0B7E9 /* Cache */ = {
+			isa = PBXGroup;
+			children = (
+				3784CC3C2CC3379A00A0B7E9 /* ImageCacheManager.swift */,
+			);
+			path = Cache;
+			sourceTree = "<group>";
+		};
 		37C0E28A2C9E58D400099A90 /* Filters */ = {
 			isa = PBXGroup;
 			children = (
@@ -346,6 +363,7 @@
 		9C1369632C9E30A10000B55C /* Andlet */ = {
 			isa = PBXGroup;
 			children = (
+				3784CC3B2CC3376A00A0B7E9 /* New Group */,
 				A9ED6DB22CAC77990066E3EA /* Analytics */,
 				9C1369F02C9E428D0000B55C /* Info.plist */,
 				9C1369D82C9E3F200000B55C /* GoogleService-Info.plist */,
@@ -360,6 +378,7 @@
 				9C528C192CAB56FB007F6A76 /* Launch Screen.storyboard */,
 				9C13696A2C9E30A20000B55C /* Andlet.entitlements */,
 				9C13696B2C9E30A20000B55C /* Preview Content */,
+				3784CC3D2CC3379A00A0B7E9 /* Cache */,
 			);
 			path = Andlet;
 			sourceTree = "<group>";
@@ -727,6 +746,7 @@
 				A9ED6DB42CAC77AC0066E3EA /* AnalyticsView.swift in Sources */,
 				9C1369CD2C9E35BE0000B55C /* ProfilePickerView.swift in Sources */,
 				9C1369D52C9E3B3D0000B55C /* ColorExtensions.swift in Sources */,
+				3784CC3E2CC3379A00A0B7E9 /* ImageCacheManager.swift in Sources */,
 				3781A9C12CA3D479000E0B86 /* OfferViewModel.swift in Sources */,
 				A9DFF6D42CAA85210063E52C /* FilterSearchOptions.swift in Sources */,
 				9C1369EB2C9E42140000B55C /* AuthenticationResultModel.swift in Sources */,

--- a/Andlet/Andlet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Andlet/Andlet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,150 @@
+{
+  "originHash" : "aec46b34ec3a592963eeff4ac3e7dd9f0bcac11637973789f9e162f13940bce4",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
+        "version" : "1.2024011602.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "21fe1af9be463a359aaf8d96789ef73fc3760d09",
+        "version" : "11.0.1"
+      }
+    },
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "c89ed571ae140f8eb1142735e6e23d7bb8c34cb2",
+        "version" : "1.7.5"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "1fc52ab0e172e7c5a961f975a76c2611f4f22852",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "07a2f57d147d2bf368a0d2dcb5579ff082d9e44f",
+        "version" : "11.1.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignin-IOS",
+      "state" : {
+        "revision" : "65fb3f1aa6ffbfdc79c4e22178a55cd91561f5e9",
+        "version" : "8.0.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
+        "version" : "8.0.2"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "f56d8fc3162de9a498377c7b6cea43431f4f5083",
+        "version" : "1.65.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "5d7d66f647400952b1758b230e019b07c0b4b22a",
+        "version" : "4.1.1"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "edb6ed4919f7756157fe02f2552b7e3850a538e5",
+        "version" : "1.28.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Andlet/Andlet/Cache/ImageCacheManager.swift
+++ b/Andlet/Andlet/Cache/ImageCacheManager.swift
@@ -1,0 +1,48 @@
+//
+//  ImageCacheManager.swift
+//  Andlet
+//
+//  Created by Sofía Torres Ramírez on 16/10/24.
+//
+
+import SwiftUI
+import FirebaseStorage
+import Combine
+
+class ImageCacheManager {
+    static let shared = ImageCacheManager()
+    private var cache = NSCache<NSString, UIImage>()
+    
+    // Función para obtener la imagen desde el caché o descargarla si no está en caché
+    func getImage(forKey key: String, completion: @escaping (UIImage?) -> Void) {
+        if let cachedImage = cache.object(forKey: key as NSString) {
+            // Si la imagen ya está en caché, devolverla
+            completion(cachedImage)
+        } else {
+            // Si no está en caché, descargarla
+            let storage = Storage.storage().reference().child("properties/\(key)")
+            storage.downloadURL { url, error in
+                guard let url = url, error == nil else {
+                    print("Error al obtener la URL de la imagen \(key): \(String(describing: error))")
+                    completion(nil)
+                    return
+                }
+                
+                // Descargar la imagen desde la URL
+                URLSession.shared.dataTask(with: url) { data, response, error in
+                    guard let data = data, let image = UIImage(data: data), error == nil else {
+                        print("Error al descargar la imagen \(key): \(String(describing: error))")
+                        completion(nil)
+                        return
+                    }
+                    
+                    // Almacenar la imagen en el caché
+                    self.cache.setObject(image, forKey: key as NSString)
+                    DispatchQueue.main.async {
+                        completion(image)
+                    }
+                }.resume()
+            }
+        }
+    }
+}

--- a/Andlet/Andlet/ViewModels/Offers/OfferViewModel.swift
+++ b/Andlet/Andlet/ViewModels/Offers/OfferViewModel.swift
@@ -50,7 +50,7 @@ class OfferViewModel: ObservableObject {
 
                 // Iterar sobre las claves dentro del documento de ofertas
                 for (key, value) in data {
-                    /*print("Clave: \(key), Valor: \(value)") */ // Imprimir cada clave y valor
+                
 
                     if let offerData = value as? [String: Any] {
                         // Filtrar por is_active == true dentro de los campos anidados

--- a/Andlet/Andlet/ViewModels/Properties/PropertyViewModel.swift
+++ b/Andlet/Andlet/ViewModels/Properties/PropertyViewModel.swift
@@ -205,7 +205,6 @@ class PropertyViewModel: ObservableObject {
     func assignAuthenticatedUser(to propertyOfferData: PropertyOfferData) {
         if let currentUser = Auth.auth().currentUser {
             propertyOfferData.userId = currentUser.email ?? "" // Asignar el correo electrónico como userId
-            print("Usuario autenticado asignado a PropertyOfferData: Email \(propertyOfferData.userId)")
         } else {
             print("No se encontró un usuario autenticado.")
         }

--- a/Andlet/Andlet/Views/Filters/FiltersSearchView.swift
+++ b/Andlet/Andlet/Views/Filters/FiltersSearchView.swift
@@ -12,7 +12,6 @@ struct FilterSearchView: View {
     @State private var localMinPrice: Double
     @State private var localMaxPrice: Double
     @State private var localMaxMinutes: Double
-    @State private var selectedOption: FilterSearchOptions = .dates
 
     init(show: Binding<Bool>, filterViewModel: FilterViewModel, offerViewModel: OfferViewModel) {
         _show = show
@@ -105,7 +104,6 @@ struct FilterSearchView: View {
                 .shadow(radius: 10)
                 
                 VStack(alignment: .leading) {
-                    if selectedOption == .prices {
                         Text("Price")
                             .font(.custom("LeagueSpartan-SemiBold", size: 28))
                             .fontWeight(.semibold)
@@ -117,22 +115,16 @@ struct FilterSearchView: View {
                             Text("$\(Int(localMaxPrice))")
                         }
                         .padding(.horizontal)
-                    } else {
-                        CollapsedPickedView(title: "Price", description: "Select price")
-                    }
                 }
                 .padding()
-                .frame(height: selectedOption == .prices ? 120 : 64)
+                .frame(height: 120)
                 .background(.white)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
                 .padding()
                 .shadow(radius: 10)
-                .onTapGesture {
-                    withAnimation(.snappy) { selectedOption = .prices }
-                }
 
                 VStack(alignment: .leading) {
-                    if selectedOption == .minutes {
+
                         Text("Minutes from campus")
                             .font(.custom("LeagueSpartan-SemiBold", size: 28))
                             .fontWeight(.semibold)
@@ -145,19 +137,13 @@ struct FilterSearchView: View {
                         }
                         .padding(.horizontal)
                         
-                    } else {
-                        CollapsedPickedView(title: "Minutes from campus", description: "Select minutes")
-                    }
                 }
                 .padding()
-                .frame(height: selectedOption == .minutes ? 120 : 64)
+                .frame(height: 120 )
                 .background(.white)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
                 .padding()
                 .shadow(radius: 10)
-                .onTapGesture {
-                    withAnimation(.snappy) { selectedOption = .minutes }
-                }
 
                 Spacer()
 

--- a/Andlet/Andlet/Views/Helpers/OfferImageCarouselView.swift
+++ b/Andlet/Andlet/Views/Helpers/OfferImageCarouselView.swift
@@ -1,29 +1,21 @@
-//
-//  OfferDetailView.swift
-//  SwiftApp
-//
-//  Created by Sofía Torres Ramírez on 16/09/24.
-//
-
 import SwiftUI
-import FirebaseStorage
 
 struct OfferImageCarouselView: View {
     let property: PropertyModel
-    @State private var imageURLs: [URL] = []
+    @State private var images: [UIImage?] = []
     
     var body: some View {
         TabView {
-            if imageURLs.isEmpty {
+            if images.isEmpty {
                 // Placeholder cuando no hay imágenes
                 Text("No images available")
             } else {
-                ForEach(imageURLs, id: \.self) { url in
-                    AsyncImage(url: url) { image in
-                        image
+                ForEach(Array(images.enumerated()), id: \.0) { index, image in
+                    if let image = image {
+                        Image(uiImage: image)
                             .resizable()
                             .scaledToFill()
-                    } placeholder: {
+                    } else {
                         // Placeholder mientras se carga la imagen
                         ProgressView()
                     }
@@ -37,37 +29,15 @@ struct OfferImageCarouselView: View {
     }
     
     func loadImages() {
-        let storage = Storage.storage()
-        var urls: [URL] = []
+        var tempImages: [UIImage?] = Array(repeating: nil, count: property.photos.count)
         
-        // Iterar sobre las rutas de las imágenes en el array "photos"
-        for photo in property.photos {
-            let storageRef = storage.reference().child("properties/\(photo)")
-            
-            // Obtener la URL de descarga
-            storageRef.downloadURL { url, error in
-                if let error = error {
-                    // Manejo de errores
-                    print("Error al obtener la URL de la imagen \(photo): \(error.localizedDescription)")
-                    return
-                }
-                
-                if let url = url {
-                    urls.append(url)
-                    
-                    // Actualizar el estado en el hilo principal
-                    DispatchQueue.main.async {
-                        imageURLs = urls
-                    }
-                } else {
-                    print("Error: No se pudo obtener la URL para la imagen \(photo)")
+        for (index, photo) in property.photos.enumerated() {
+            ImageCacheManager.shared.getImage(forKey: photo) { image in
+                DispatchQueue.main.async {
+                    tempImages[index] = image
+                    self.images = tempImages
                 }
             }
         }
     }
-    
 }
-
-//#Preview{
-//    OfferImageCarouselView()
-//}

--- a/Andlet/Andlet/Views/Homepage/HomepageView.swift
+++ b/Andlet/Andlet/Views/Homepage/HomepageView.swift
@@ -6,6 +6,7 @@ import UIKit
 struct HomepageView: View {
     @State private var showFilterSearchView = false
     @State private var showShakeAlert = false
+    @State private var showConfirmationAlert = false
     @StateObject private var offerViewModel = OfferViewModel()
     @State private var userRoommatePreference: Bool? = nil
     @StateObject private var filterViewModel = FilterViewModel(
@@ -62,19 +63,28 @@ struct HomepageView: View {
                         .onAppear {
                             
                             fetchUserViewPreferences()
+                            let cache = URLCache.shared
+                            print("Cache actual: \(cache.currentMemoryUsage) bytes en memoria y \(cache.currentDiskUsage) bytes en disco.")
+
                             
                         }
                         .background(
                             ShakeHandlingControllerRepresentable(shakeDetector: shakeDetector)
                                 .frame(width: 0, height: 0)
                         )
-                        .alert(isPresented: $showShakeAlert) {
-                            Alert(title: Text("Shake Detected"), message: Text("Filters have been cleared🧹!"), dismissButton: .default(Text("OK")))
-                        }
+                        .alert(isPresented: $showConfirmationAlert) {
+                                                    Alert(
+                                                        title: Text("Shake Detected"),
+                                                        message: Text("Do you want to clear the filters / refresh the offers?🧹"),
+                                                        primaryButton: .destructive(Text("Yes")) {
+                                                            refreshOffers()
+                                                        },
+                                                        secondaryButton: .cancel(Text("No"))
+                                                    )
+                                                }
                         .onReceive(shakeDetector.$didShake) { didShake in
                             if didShake {
-                                showShakeAlert = true
-                                refreshOffers()
+                                showConfirmationAlert = true
                                 shakeDetector.resetShake()
                             }
                         }

--- a/Andlet/Andlet/Views/Offers/OfferRentView.swift
+++ b/Andlet/Andlet/Views/Offers/OfferRentView.swift
@@ -44,6 +44,15 @@ struct OfferRentView: View {
                     Text(property.address)
                         .font(.custom("LeagueSpartan-ExtraLight", size: 16))
                         .foregroundColor(Color(hex: "000000"))
+                    
+                }
+                .foregroundColor(.gray)
+                
+                HStack {
+                
+                    Text("\(formattedDate(offer.initialDate)) - \(formattedDate(offer.finalDate))")
+                        .font(.custom("LeagueSpartan-Light", size: 16))
+                        .foregroundColor(Color(hex: "000000"))
                 }
                 .foregroundColor(.gray)
 
@@ -84,7 +93,7 @@ struct OfferRentView: View {
                         Circle()
                             .stroke(isSold ? Color.clear : Color.black, lineWidth: 1)
                             .background(isSold ? Circle().foregroundColor(.black) : nil)
-                            .frame(width: 16, height: 16)
+                            .frame(width: 20, height: 20)
 
                         Button(action: {
                             isSold.toggle() 
@@ -99,7 +108,7 @@ struct OfferRentView: View {
                             )
                         }) {
                             Text(isSold ? "Leased" : "Available")
-                                .font(.custom("LeagueSpartan-Medium", size: 16))
+                                .font(.custom("LeagueSpartan-Medium", size: 20))
                                 .foregroundColor(.black)
                         }
                     }
@@ -110,4 +119,11 @@ struct OfferRentView: View {
         }
         .padding()
     }
+    
+    // Función para formatear las fechas
+       func formattedDate(_ date: Date) -> String {
+           let dateFormatter = DateFormatter()
+           dateFormatter.dateStyle = .medium
+           return dateFormatter.string(from: date)
+       }
 }


### PR DESCRIPTION
- The photos in the homepage and the detail view now persists and uses cache
- In the Homepage offers now the available/leased button is bigger and the landlord can see the available dates
- In the filters view now it is possible to see all the filters at the same time
- And when the user shakes their phone now the app ask the user if they want to clear the filters