### PR TITLE
58 implementing local storage for a property

### DIFF
--- a/Andlet/Andlet/ViewModels/Properties/PropertyOfferData.swift
+++ b/Andlet/Andlet/ViewModels/Properties/PropertyOfferData.swift
@@ -76,4 +76,27 @@ class PropertyOfferData: ObservableObject, CustomStringConvertible {
         - Roommates: \(roommates)
         """
     }
+    
+    // Método para reiniciar todos los datos de la propiedad
+    func reset() {
+        placeTitle = ""
+        placeDescription = ""
+        placeAddress = ""
+        photos = []
+        selectedImagesData = []
+        numBaths = 1
+        numBeds = 1
+        numRooms = 1
+        pricePerMonth = 0.0
+        type = .aRoom
+        onlyAndes = false
+        initialDate = Date()
+        finalDate = Calendar.current.date(byAdding: .day, value: 7, to: Date()) ?? Date()
+        minutesFromCampus = 0
+        userId = ""
+        userName = ""
+        userEmail = ""
+        propertyID = 0
+        updateRoommates()
+    }
 }

--- a/Andlet/Andlet/Views/Forms/Step3View.swift
+++ b/Andlet/Andlet/Views/Forms/Step3View.swift
@@ -8,10 +8,12 @@ struct Step3View: View {
     @StateObject private var networkMonitor = NetworkMonitor()
 
     @AppStorage("publishedOffline") private var publishedOffline = false // Estado de publicación offline
+    @AppStorage("currentOfferCountStorage") private var currentOfferCountStorage = 0 // Contador de ofertas actuales persistente
     @State private var showNoInternetAlert = false
     @State private var showWarningMessage = false
     @State private var isSaving = false
     @State private var navigateToMainTab = false
+    @State private var showFirstPropertyWarning = false // Para advertencia de la primera propiedad sin conexión
 
     var body: some View {
         NavigationStack {
@@ -92,16 +94,25 @@ struct Step3View: View {
                                     let todayStartOfDay = Calendar.current.startOfDay(for: Date())
 
                                     if propertyOfferData.initialDate >= todayStartOfDay && propertyOfferData.finalDate > propertyOfferData.initialDate {
-                                        isSaving = true
-
+                                        // Verificar la conexión y si es la primera propiedad
                                         if !networkMonitor.isConnected {
-                                            publishedOffline = true // Marcar como publicado sin conexión
-                                            showNoInternetAlert = true
-                                            DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-                                                showNoInternetAlert = false
-                                                completeSave()
+                                            if currentOfferCountStorage == 0 {
+                                                // Mostrar advertencia específica para la primera propiedad y redirigir a HomepageRentView
+                                                showFirstPropertyWarning = true
+                                                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                                    navigateToMainTab = true
+                                                }
+                                            } else {
+                                                // Configuración de publicación offline para propiedades adicionales
+                                                publishedOffline = true
+                                                showNoInternetAlert = true
+                                                DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                                                    showNoInternetAlert = false
+                                                    completeSave()
+                                                }
                                             }
                                         } else {
+                                            isSaving = true
                                             publishedOffline = false
                                             completeSave()
                                         }
@@ -118,7 +129,27 @@ struct Step3View: View {
                     .padding()
                 }
 
-                if showNoInternetAlert {
+                // Mostrar advertencia para la primera propiedad sin conexión
+                if showFirstPropertyWarning {
+                    ZStack {
+                        Color(hex: "#FFC5C5").ignoresSafeArea() // Color de fondo para advertencia
+                        VStack(spacing: 20) {
+                            Text("⚠️ Internet connection is required to publish your first property.")
+                                .font(.body)
+                                .foregroundColor(.black)
+                                .multilineTextAlignment(.center)
+                                .padding()
+                                .background(Color(hex: "#FFF4CF"))
+                                .cornerRadius(10)
+                                .frame(width: 300)
+                        }
+                    }
+                    .transition(.opacity)
+                    .animation(.easeInOut(duration: 0.3), value: showFirstPropertyWarning)
+                }
+
+                // Mostrar advertencia para publicación offline en propiedades adicionales
+                if showNoInternetAlert && currentOfferCountStorage > 0 {
                     ZStack {
                         Color(hex: "#C5DDFF").ignoresSafeArea()
                         VStack(spacing: 20) {

--- a/Andlet/Andlet/Views/Forms/Step3View.swift
+++ b/Andlet/Andlet/Views/Forms/Step3View.swift
@@ -7,7 +7,7 @@ struct Step3View: View {
     @StateObject private var viewModel = PropertyViewModel()
     @StateObject private var networkMonitor = NetworkMonitor()
 
-    @AppStorage("publishedOffline") private var publishedOffline = false // Almacenar estado offline
+    @AppStorage("publishedOffline") private var publishedOffline = false // Estado de publicación offline
     @State private var showNoInternetAlert = false
     @State private var showWarningMessage = false
     @State private var isSaving = false
@@ -110,7 +110,7 @@ struct Step3View: View {
                                         isSaving = false
                                     }
                                 }
-                                .disabled(isSaving)
+                                .disabled(isSaving || (publishedOffline && !networkMonitor.isConnected))
                         }
                         .padding(.horizontal, 20)
                         .padding(.top, 10)
@@ -157,7 +157,7 @@ struct Step3View: View {
                 }
             }
             .navigationDestination(isPresented: $navigateToMainTab) {
-                MainTabLandlordView()
+                HomepageRentView()
                     .navigationBarBackButtonHidden(true)
                     .navigationBarHidden(true)
             }

--- a/Andlet/Andlet/Views/HomepageRent/CreateMoreButton.swift
+++ b/Andlet/Andlet/Views/HomepageRent/CreateMoreButton.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 
-// Actualización de CreateMoreButton
 struct CreateMoreButton: View {
+    @AppStorage("publishedOffline") private var publishedOffline = false
+    @State var isConnected: Bool // Pasar el estado de conexión
+    @State var showOfflineAlert = false // Controla la alerta cuando el botón está desactivado
+    
     var body: some View {
         HStack {
             Text("Your listings")
@@ -10,24 +13,33 @@ struct CreateMoreButton: View {
                 .fontWeight(.bold)
             Spacer()
             
-            // Crear un nuevo PropertyOfferData y pasarlo a Step1View
-            NavigationLink(destination: Step1View(propertyOfferData: PropertyOfferData())
-                .navigationBarBackButtonHidden()
-                .toolbar(.hidden, for: .tabBar)
-                .ignoresSafeArea(.all)) {
-                Text("+ Create more")
-                    .foregroundStyle(.white)
-                    .font(.subheadline)
-                    .frame(width: 130, height: 45)
-                    .background(Color(hex: "0C356A"))
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            Button(action: {
+                if publishedOffline && !isConnected {
+                    showOfflineAlert = true // Mostrar la alerta si el botón está desactivado
+                }
+            }) {
+                NavigationLink(destination: Step1View(propertyOfferData: PropertyOfferData())
+                    .navigationBarBackButtonHidden()
+                    .toolbar(.hidden, for: .tabBar)
+                    .ignoresSafeArea(.all)) {
+                    Text("+ Create more")
+                        .foregroundStyle(.white)
+                        .font(.subheadline)
+                        .frame(width: 130, height: 45)
+                        .background(publishedOffline && !isConnected ? Color.gray : Color(hex: "0C356A"))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+            }
+            .disabled(publishedOffline && !isConnected) // Desactiva el botón si se publicó offline y no hay conexión
+            .alert(isPresented: $showOfflineAlert) {
+                Alert(
+                    title: Text("Offline Limit Reached"),
+                    message: Text("You can only publish one property without internet connection."),
+                    dismissButton: .default(Text("OK"))
+                )
             }
         }
         .padding(.horizontal)
         .padding(.top, 10)
     }
 }
-
-//#Preview {
-//    CreateMoreButton()
-//}

--- a/Andlet/Andlet/Views/HomepageRent/CreateMoreButton.swift
+++ b/Andlet/Andlet/Views/HomepageRent/CreateMoreButton.swift
@@ -23,10 +23,10 @@ struct CreateMoreButton: View {
                     .toolbar(.hidden, for: .tabBar)
                     .ignoresSafeArea(.all)) {
                     Text("+ Create more")
-                        .foregroundStyle(.white)
+                        .foregroundColor(.white)
                         .font(.subheadline)
                         .frame(width: 130, height: 45)
-                        .background(publishedOffline && !isConnected ? Color.gray : Color(hex: "0C356A"))
+                        .background(publishedOffline && !isConnected ? Color.gray : Color(hex: "0C356A")) // Cambia a gris si está desactivado
                         .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
             }


### PR DESCRIPTION
This pull request introduces several enhancements to the property offer management and user interface in the Andlet application. The key changes include the addition of a reset method for property data, improvements to offline property publishing, and updates to the user interface for better offline handling.

### Enhancements to Property Management:

* Added a `reset` method in `PropertyOfferData` to clear all property data fields. (`Andlet/Andlet/ViewModels/Properties/PropertyOfferData.swift`)

### Improvements to Offline Property Publishing:

* Introduced a persistent counter for current offers using `@AppStorage` and added logic to handle the first offline property differently, including a specific warning message. (`Andlet/Andlet/Views/Forms/Step3View.swift`) [[1]](diffhunk://#diff-248482c12be1b6d55789851ee4caed9875b0f64c5e601583bdaa6b3fb420e259L10-R16) [[2]](diffhunk://#diff-248482c12be1b6d55789851ee4caed9875b0f64c5e601583bdaa6b3fb420e259L95-R115) [[3]](diffhunk://#diff-248482c12be1b6d55789851ee4caed9875b0f64c5e601583bdaa6b3fb420e259L113-R152) [[4]](diffhunk://#diff-248482c12be1b6d55789851ee4caed9875b0f64c5e601583bdaa6b3fb420e259L160-R191)
* Updated `CreateMoreButton` to disable the button and show an alert if the user tries to create more than one property offline. (`Andlet/Andlet/Views/HomepageRent/CreateMoreButton.swift`) [[1]](diffhunk://#diff-373fdd4a3334b759bcc4d5d6cea54fe36e19be55fad42068705a5a7f07a9619dL3-R7) [[2]](diffhunk://#diff-373fdd4a3334b759bcc4d5d6cea54fe36e19be55fad42068705a5a7f07a9619dL13-L33)

### User Interface Updates:

* Updated `HomepageRentView` to include the persistent offer count and handle the offline state more effectively, including disabling the `CreateMoreButton` when offline and showing relevant alerts. (`Andlet/Andlet/Views/HomepageRent/HomepageRentView.swift`) [[1]](diffhunk://#diff-a3a0bb37b5d00a01fb50e0d6d320f6685d6b610f91fe092ea23cba43ada059ccL6-R9) [[2]](diffhunk://#diff-a3a0bb37b5d00a01fb50e0d6d320f6685d6b610f91fe092ea23cba43ada059ccR19) [[3]](diffhunk://#diff-a3a0bb37b5d00a01fb50e0d6d320f6685d6b610f91fe092ea23cba43ada059ccL30-R34) [[4]](diffhunk://#diff-a3a0bb37b5d00a01fb50e0d6d320f6685d6b610f91fe092ea23cba43ada059ccL46-L48) [[5]](diffhunk://#diff-a3a0bb37b5d00a01fb50e0d6d320f6685d6b610f91fe092ea23cba43ada059ccR69-L83) [[6]](diffhunk://#diff-a3a0bb37b5d00a01fb50e0d6d320f6685d6b610f91fe092ea23cba43ada059ccL94) [[7]](diffhunk://#diff-a3a0bb37b5d00a01fb50e0d6d320f6685d6b610f91fe092ea23cba43ada059ccL106-R117) [[8]](diffhunk://#diff-a3a0bb37b5d00a01fb50e0d6d320f6685d6b610f91fe092ea23cba43ada059ccR138-R161)