### PR TITLE
Add conection check before trigger log in or sign in

### DIFF
--- a/Andlet/Andlet/Views/WelcomeViews/AuthenticationView.swift
+++ b/Andlet/Andlet/Views/WelcomeViews/AuthenticationView.swift
@@ -148,7 +148,7 @@ struct AuthenticationView: View {
             .navigationBarHidden(true)
             .alert(isPresented: Binding(get: { errorMessage != nil }, set: { _ in errorMessage = nil })) {
                 Alert(
-                    title: Text("Authentication Error"),
+                    title: Text(connectivityChecker.isConnected ? "Authentication Error" : "Connection Error"),
                     message: Text(errorMessage ?? "Unknown error"),
                     dismissButton: .default(Text("OK"))
                 )

--- a/Andlet/Andlet/Views/WelcomeViews/AuthenticationView.swift
+++ b/Andlet/Andlet/Views/WelcomeViews/AuthenticationView.swift
@@ -1,6 +1,32 @@
 import SwiftUI
 import GoogleSignIn
 import GoogleSignInSwift
+import Network
+
+class ConnectivityChecker: ObservableObject {
+    @Published var isConnected: Bool = true
+    private var monitor: NWPathMonitor
+    private let queue = DispatchQueue(label: "NetworkMonitor")
+
+    init() {
+        self.monitor = NWPathMonitor()
+        self.startMonitoring()
+    }
+
+    deinit {
+        monitor.cancel()
+    }
+
+    private func startMonitoring() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            DispatchQueue.main.async {
+                self?.isConnected = path.status == .satisfied
+            }
+        }
+        monitor.start(queue: queue)
+    }
+}
+
 
 @MainActor
 struct AuthenticationView: View {
@@ -9,6 +35,7 @@ struct AuthenticationView: View {
     @State private var isLoading: Bool = false
     @State private var destination: NavigationDestination?  // Manage navigation state
     @State private var errorMessage: String? = nil  // To display errors
+    @StateObject private var connectivityChecker: ConnectivityChecker = ConnectivityChecker()
 
     // Enum to manage different navigation destinations
     enum NavigationDestination: Hashable {
@@ -53,7 +80,7 @@ struct AuthenticationView: View {
                     }
 
                     // Google Sign-In Button
-                    Button(action: signInWithGoogle) {
+                    Button(action: checkConnectivityBeforeSignIn) {
                         HStack {
                             Image("GoogleIcon")
                                 .resizable()
@@ -86,7 +113,7 @@ struct AuthenticationView: View {
                     }
 
                     // Log in with Google Button
-                    Button(action: signInWithGoogle) {
+                    Button(action: checkConnectivityBeforeSignIn) {
                         HStack {
                             Image("GoogleIcon")
                                 .resizable()
@@ -150,6 +177,13 @@ struct AuthenticationView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color(red: 197/255, green: 221/255, blue: 255/255))
             .transition(.opacity)
+        }
+    }
+    private func checkConnectivityBeforeSignIn() {
+        if connectivityChecker.isConnected {
+            signInWithGoogle()
+        } else {
+            errorMessage = "No internet connection. Please connect to the internet and try again."
         }
     }
 


### PR DESCRIPTION
This pull request introduces a new `ConnectivityChecker` class and updates the `AuthenticationView` to check for internet connectivity before attempting Google Sign-In. The key changes include the addition of the connectivity checker and modifications to the sign-in button actions.

Enhancements to connectivity checking:

* [`Andlet/Andlet/Views/WelcomeViews/AuthenticationView.swift`](diffhunk://#diff-d2275d17a334e1eeec84c7c20ff13ee9bdc4662d36b0f62c7e317708f631c86eR4-R29): Introduced a new `ConnectivityChecker` class to monitor internet connectivity.
* [`Andlet/Andlet/Views/WelcomeViews/AuthenticationView.swift`](diffhunk://#diff-d2275d17a334e1eeec84c7c20ff13ee9bdc4662d36b0f62c7e317708f631c86eR38): Added a `@StateObject` for `ConnectivityChecker` in the `AuthenticationView` to observe connectivity status.

Modifications to sign-in process:

* [`Andlet/Andlet/Views/WelcomeViews/AuthenticationView.swift`](diffhunk://#diff-d2275d17a334e1eeec84c7c20ff13ee9bdc4662d36b0f62c7e317708f631c86eL56-R83): Updated the Google Sign-In button action to use `checkConnectivityBeforeSignIn` instead of directly calling `signInWithGoogle`. [[1]](diffhunk://#diff-d2275d17a334e1eeec84c7c20ff13ee9bdc4662d36b0f62c7e317708f631c86eL56-R83) [[2]](diffhunk://#diff-d2275d17a334e1eeec84c7c20ff13ee9bdc4662d36b0f62c7e317708f631c86eL89-R116)
* [`Andlet/Andlet/Views/WelcomeViews/AuthenticationView.swift`](diffhunk://#diff-d2275d17a334e1eeec84c7c20ff13ee9bdc4662d36b0f62c7e317708f631c86eR182-R188): Added the `checkConnectivityBeforeSignIn` method to check connectivity status before attempting to sign in.