### PR TITLE
[Bug-fix] Not allowing New Lines on Form Fields

### DIFF
--- a/Andlet/Andlet/Views/Helpers/StringExtensions.swift
+++ b/Andlet/Andlet/Views/Helpers/StringExtensions.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension String {
     var isOnlyWhitespace: Bool {
-        return self.trimmingCharacters(in: .whitespaces).isEmpty
+        return self.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     var containsEmoji: Bool {
@@ -10,8 +10,10 @@ extension String {
     }
     
     func removingExtraSpaces() -> String {
-        return self.trimmingCharacters(in: .whitespaces)
-                   .components(separatedBy: .whitespaces)
+        // Reemplazar saltos de línea con un espacio, luego eliminar espacios adicionales
+        return self.replacingOccurrences(of: "\n", with: " ")
+                   .trimmingCharacters(in: .whitespacesAndNewlines)
+                   .components(separatedBy: .whitespacesAndNewlines)
                    .filter { !$0.isEmpty }
                    .joined(separator: " ")
     }


### PR DESCRIPTION
This pull request includes changes to the `Andlet/Andlet/Views/Helpers/StringExtensions.swift` file to improve the handling of whitespace and newlines in string operations. The most important changes include updating the `isOnlyWhitespace` property and modifying the `removingExtraSpaces` method.

Improvements to whitespace and newline handling:

* `isOnlyWhitespace` property: Updated to use `.whitespacesAndNewlines` instead of just `.whitespaces` to ensure that newlines are also considered when checking if a string is only whitespace.
* `removingExtraSpaces` method: Modified to replace newline characters with spaces before trimming and splitting the string, ensuring that extra spaces are removed more effectively.