### PR TITLE
Feature removed

### DIFF
--- a/Andlet/Andlet/Views/Helpers/MainTabView.swift
+++ b/Andlet/Andlet/Views/Helpers/MainTabView.swift
@@ -43,7 +43,7 @@ struct MainTabView: View {
                     .foregroundStyle(Color(hex: "0C356A"))
                 }
                 .tag(Tab.explore)
-            SavedOffersView(offerViewModel: offerSavedViewModel, filterViewModel: filterViewModel, showNoConectionBanner: $showNoConnectionBanner)
+            SavedOffersView(offerViewModel: offerSavedViewModel, showNoConectionBanner: $showNoConnectionBanner)
                 .tabItem {
                     Label("Saved", systemImage: "bookmark.fill"
                     )

--- a/Andlet/Andlet/Views/Offers/SavedOffersView.swift
+++ b/Andlet/Andlet/Views/Offers/SavedOffersView.swift
@@ -28,26 +28,19 @@ struct SavedOffersView: View {
     var body: some View {
         if #available(iOS 16.0, *) {
             NavigationStack {
-                if showFilterSearchView {
-                    FilterSearchSavedView(
-                        show: $showFilterSearchView,
-                        filterViewModel: filterViewModel,
-                        offerViewModel: offerViewModel
-                    )
-                } else {
                     ScrollView {
                         VStack {
                             Spacer()
                             Heading()
-                            SearchAndFilterSavedBar(
-                                filterViewModel: filterViewModel,
-                                offerViewModel: offerViewModel
-                            )
-                            .onTapGesture {
-                                withAnimation(.snappy) {
-                                    showFilterSearchView.toggle()
-                                }
-                            }
+//                            SearchAndFilterSavedBar(
+//                                filterViewModel: filterViewModel,
+//                                offerViewModel: offerViewModel
+//                            )
+//                            .onTapGesture {
+//                                withAnimation(.snappy) {
+//                                    showFilterSearchView.toggle()
+//                                }
+//                            }
                             
                             Text("Your saved places")
                                 .font(.custom("LeagueSpartan-SemiBold", size: 22))
@@ -149,8 +142,7 @@ struct SavedOffersView: View {
                         }
                     }
                 }
-            }
-            .navigationBarBackButtonHidden(true)
+                .navigationBarBackButtonHidden(true)
         } else {
             Text("Version not supported")
         }
@@ -158,14 +150,10 @@ struct SavedOffersView: View {
 
     // MARK: - Initialization
     func initializeData() async {
-        fetchUserViewPreferences() // No asíncrono, corre inmediatamente.
-
+//        fetchUserViewPreferences() // No asíncrono, corre inmediatamente.
         // Manejo de fetch de ofertas
-        if filterViewModel.filtersApplied {
-            offerViewModel.fetchOffersWithFilters()
-        } else {
-            offerViewModel.fetchSavedOffers()
-        }
+        offerViewModel.fetchSavedOffers()
+        
     }
 
     func fetchUserViewPreferences() {

--- a/Andlet/Andlet/Views/Offers/SavedOffersView.swift
+++ b/Andlet/Andlet/Views/Offers/SavedOffersView.swift
@@ -10,18 +10,15 @@ struct SavedOffersView: View {
     @ObservedObject private var networkMonitor = NetworkMonitor()
     @ObservedObject private var offerViewModel: SavedOffersViewModel
     @State private var userRoommatePreference: Bool? = nil
-    @ObservedObject private var filterViewModel: FilterViewModel
     @StateObject private var shakeDetector = ShakeDetector()
     @State private var selectedOffer: OfferWithProperty?
     @State private var isInitialized = false
     
     public init(
         offerViewModel: SavedOffersViewModel,
-        filterViewModel: FilterViewModel,
         showNoConectionBanner: Binding<Bool>
     ) {
         self.offerViewModel = offerViewModel
-        self.filterViewModel = filterViewModel
         self._showNoConnectionBanner = showNoConectionBanner
     }
   
@@ -98,7 +95,6 @@ struct SavedOffersView: View {
                                 title: Text("Shake Detected"),
                                 message: Text("Do you want to clear the filters?🧹"),
                                 primaryButton: .destructive(Text("Yes")) {
-                                    filterViewModel.clearFilters()
                                     offerViewModel.fetchSavedOffers()
                                 },
                                 secondaryButton: .cancel(Text("No"))


### PR DESCRIPTION
This pull request involves modifications to the `SavedOffersView` in the `Andlet/Andlet/Views/Offers/SavedOffersView.swift` file. The changes are primarily focused on commenting out certain functionalities related to the filter search view and user view preferences.

### Key Changes:

**Commented Out Filter Search View Functionality:**
* The `FilterSearchSavedView` and `SearchAndFilterSavedBar` components, along with their related tap gesture and animation, have been commented out.
* The conditional check for `showFilterSearchView` has been removed, simplifying the view structure.

**Initialization Function Adjustments:**
* The `fetchUserViewPreferences` call in the `initializeData` function has been commented out.
* The conditional check for `filterViewModel.filtersApplied` has been removed, leaving only the `offerViewModel.fetchSavedOffers` call.